### PR TITLE
Add InterlockedHL_WaitForNotValue with code and tests

### DIFF
--- a/adapters/interlocked_hl_win32.c
+++ b/adapters/interlocked_hl_win32.c
@@ -21,7 +21,7 @@ IMPLEMENT_MOCKABLE_FUNCTION(, INTERLOCKED_HL_RESULT, InterlockedHL_Add64WithCeil
         (originalAddend == NULL)
         )
     {
-        LogError("invalid arguments LONGLONG volatile * Addend=%p, LONGLONG Ceiling=%I64d, LONGLONG Value=%I64d, LONGLONG* originalAddend=%p", 
+        LogError("invalid arguments LONGLONG volatile * Addend=%p, LONGLONG Ceiling=%I64d, LONGLONG Value=%I64d, LONGLONG* originalAddend=%p",
             Addend, Ceiling, Value, originalAddend);
         result = INTERLOCKED_HL_ERROR;
     }
@@ -103,11 +103,50 @@ IMPLEMENT_MOCKABLE_FUNCTION(, INTERLOCKED_HL_RESULT, InterlockedHL_WaitForValue,
             /* Codes_SRS_INTERLOCKED_HL_01_008: [ If the value at address does not match, InterlockedHL_WaitForValue shall issue another call to WaitOnAddress. ]*/
 
             /* Codes_SRS_INTERLOCKED_HL_01_004: [ If the value at address is not equal to value, InterlockedHL_WaitForValue shall wait until the value at address changes in order to compare it again to value by using WaitOnAddress. ]*/
-            /* Codes_SRS_INTERLOCKED_HL_01_003: [ If the value at address is equal to value, InterlockedHL_WaitForValue shall return INTERLOCKED_HL_OK. ]*/
             /* Codes_SRS_INTERLOCKED_HL_01_005: [ When waiting for the value at address to change, the milliseconds argument value shall be used as timeout. ]*/
             if (!WaitOnAddress(address, &current_value, sizeof(current_value), milliseconds))
             {
                 /* Codes_SRS_INTERLOCKED_HL_01_006: [ If WaitOnAddress fails, InterlockedHL_WaitForValue shall fail and return INTERLOCKED_HL_ERROR. ]*/
+                result = INTERLOCKED_HL_ERROR;
+                break;
+            }
+        } while (1);
+    }
+
+    return result;
+}
+
+IMPLEMENT_MOCKABLE_FUNCTION(, INTERLOCKED_HL_RESULT, InterlockedHL_WaitForNotValue, LONG volatile*, address, LONG, value, DWORD, milliseconds)
+{
+    INTERLOCKED_HL_RESULT result;
+
+    /* Codes_SRS_INTERLOCKED_HL_42_001: [ If address is NULL, InterlockedHL_WaitForNotValue shall fail and return INTERLOCKED_HL_ERROR. ]*/
+    if (address == NULL)
+    {
+        result = INTERLOCKED_HL_ERROR;
+    }
+    else
+    {
+        LONG current_value;
+
+        do
+        {
+            /* Codes_SRS_INTERLOCKED_HL_42_005: [ When WaitOnAddress succeeds, the value at address shall be compared to the target value passed in value by using InterlockedAdd. ]*/
+            current_value = InterlockedAdd(address, 0);
+            if (current_value != value)
+            {
+                /* Codes_SRS_INTERLOCKED_HL_42_002: [ If the value at address is not equal to value, InterlockedHL_WaitForNotValue shall return INTERLOCKED_HL_OK. ]*/
+                result = INTERLOCKED_HL_OK;
+                break;
+            }
+
+            /* Codes_SRS_INTERLOCKED_HL_42_006: [ If the value at address matches, InterlockedHL_WaitForNotValue shall issue another call to WaitOnAddress. ]*/
+
+            /* Codes_SRS_INTERLOCKED_HL_42_003: [ If the value at address is equal to value, InterlockedHL_WaitForNotValue shall wait until the value at address changes in order to compare it again to value by using WaitOnAddress. ]*/
+            /* Codes_SRS_INTERLOCKED_HL_42_004: [ When waiting for the value at address to change, the milliseconds argument value shall be used as timeout. ]*/
+            if (!WaitOnAddress(address, &current_value, sizeof(current_value), milliseconds))
+            {
+                /* Codes_SRS_INTERLOCKED_HL_42_007: [ If WaitOnAddress fails, InterlockedHL_WaitForNotValue shall fail and return INTERLOCKED_HL_ERROR. ]*/
                 result = INTERLOCKED_HL_ERROR;
                 break;
             }

--- a/devdoc/interlocked_hl_requirements.md
+++ b/devdoc/interlocked_hl_requirements.md
@@ -20,6 +20,7 @@ typedef bool (*INTERLOCKED_COMPARE_EXCHANGE_64_IF)(LONG64 target, LONG64 exchang
 MOCKABLE_FUNCTION_WITH_RETURNS(, INTERLOCKED_HL_RESULT, InterlockedHL_Add64WithCeiling, LONG64 volatile*, Addend, LONG64, Ceiling, LONG64, Value, LONG64*, originalAddend)(INTERLOCKED_HL_OK, INTERLOCKED_HL_ERROR);
 MOCKABLE_FUNCTION_WITH_RETURNS(, INTERLOCKED_HL_RESULT, InterlockedHL_SetAndWake, LONG volatile*, address, LONG, value)(INTERLOCKED_HL_OK, INTERLOCKED_HL_ERROR);
 MOCKABLE_FUNCTION_WITH_RETURNS(, INTERLOCKED_HL_RESULT, InterlockedHL_WaitForValue, LONG volatile*, address, LONG, value, DWORD, milliseconds)(INTERLOCKED_HL_OK, INTERLOCKED_HL_ERROR);
+MOCKABLE_FUNCTION_WITH_RETURNS(, INTERLOCKED_HL_RESULT, InterlockedHL_WaitForNotValue, LONG volatile*, address, LONG, value, DWORD, milliseconds)(INTERLOCKED_HL_OK, INTERLOCKED_HL_ERROR);
 MOCKABLE_FUNCTION_WITH_RETURNS(, INTERLOCKED_HL_RESULT, InterlockedHL_CompareExchange64If, LONG64 volatile*, target, LONG64, exchange, INTERLOCKED_COMPARE_EXCHANGE_64_IF, compare, LONG64 *, original_target)(INTERLOCKED_HL_OK, INTERLOCKED_HL_ERROR);
 
 ```
@@ -56,7 +57,7 @@ MOCKABLE_FUNCTION_WITH_RETURNS(, INTERLOCKED_HL_RESULT, InterlockedHL_WaitForVal
 
 `InterlockedHL_WaitForValue` waits for the value at a given address to be equal to a target value.
 
-**SRS_INTERLOCKED_HL_01_002: [** If `address` is NULL, `InterlockedHL_WaitForValue` shall fail and return `INTERLOCKED_HL_ERROR`. **]**
+**SRS_INTERLOCKED_HL_01_002: [** If `address` is `NULL`, `InterlockedHL_WaitForValue` shall fail and return `INTERLOCKED_HL_ERROR`. **]**
 
 **SRS_INTERLOCKED_HL_01_003: [** If the value at `address` is equal to `value`, `InterlockedHL_WaitForValue` shall return `INTERLOCKED_HL_OK`. **]**
 
@@ -70,6 +71,27 @@ MOCKABLE_FUNCTION_WITH_RETURNS(, INTERLOCKED_HL_RESULT, InterlockedHL_WaitForVal
 
 **SRS_INTERLOCKED_HL_01_006: [** If `WaitOnAddress` fails, `InterlockedHL_WaitForValue` shall fail and return `INTERLOCKED_HL_ERROR`. **]**
 
+### InterlockedHL_WaitForNotValue
+
+```c
+MOCKABLE_FUNCTION_WITH_RETURNS(, INTERLOCKED_HL_RESULT, InterlockedHL_WaitForNotValue, LONG volatile*, address, LONG, value, DWORD, milliseconds)(INTERLOCKED_HL_OK, INTERLOCKED_HL_ERROR);
+```
+
+`InterlockedHL_WaitForNotValue` waits for the value at a given address to not be equal to a target value.
+
+**SRS_INTERLOCKED_HL_42_001: [** If `address` is `NULL`, `InterlockedHL_WaitForNotValue` shall fail and return `INTERLOCKED_HL_ERROR`. **]**
+
+**SRS_INTERLOCKED_HL_42_002: [** If the value at `address` is not equal to `value`, `InterlockedHL_WaitForNotValue` shall return `INTERLOCKED_HL_OK`. **]**
+
+**SRS_INTERLOCKED_HL_42_003: [** If the value at `address` is equal to `value`, `InterlockedHL_WaitForNotValue` shall wait until the value at `address` changes in order to compare it again to `value` by using `WaitOnAddress`. **]**
+
+**SRS_INTERLOCKED_HL_42_004: [** When waiting for the value at address to change, the `milliseconds` argument value shall be used as timeout. **]**
+
+**SRS_INTERLOCKED_HL_42_005: [** When `WaitOnAddress` succeeds, the value at address shall be compared to the target value passed in `value` by using `InterlockedAdd`. **]**
+
+**SRS_INTERLOCKED_HL_42_006: [** If the value at `address` matches, `InterlockedHL_WaitForNotValue` shall issue another call to `WaitOnAddress`. **]**
+
+**SRS_INTERLOCKED_HL_42_007: [** If `WaitOnAddress` fails, `InterlockedHL_WaitForNotValue` shall fail and return `INTERLOCKED_HL_ERROR`. **]**
 
 ### InterlockedHL_CompareExchange64If
 ```c

--- a/inc/azure_c_util/interlocked_hl.h
+++ b/inc/azure_c_util/interlocked_hl.h
@@ -14,7 +14,7 @@
 #include "umock_c/umock_c_prod.h"
 #ifdef __cplusplus
 extern "C" {
-#endif 
+#endif
 
 #define INTERLOCKED_HL_RESULT_VALUES \
     INTERLOCKED_HL_OK, \
@@ -28,6 +28,7 @@ typedef bool (*INTERLOCKED_COMPARE_EXCHANGE_64_IF)(LONG64 target, LONG64 exchang
 MOCKABLE_FUNCTION_WITH_RETURNS(, INTERLOCKED_HL_RESULT, InterlockedHL_Add64WithCeiling, LONG64 volatile*, Addend, LONG64, Ceiling, LONG64, Value, LONG64*, originalAddend)(INTERLOCKED_HL_OK, INTERLOCKED_HL_ERROR);
 MOCKABLE_FUNCTION_WITH_RETURNS(, INTERLOCKED_HL_RESULT, InterlockedHL_SetAndWake, LONG volatile*, address, LONG, value)(INTERLOCKED_HL_OK, INTERLOCKED_HL_ERROR);
 MOCKABLE_FUNCTION_WITH_RETURNS(, INTERLOCKED_HL_RESULT, InterlockedHL_WaitForValue, LONG volatile*, address, LONG, value, DWORD, milliseconds)(INTERLOCKED_HL_OK, INTERLOCKED_HL_ERROR);
+MOCKABLE_FUNCTION_WITH_RETURNS(, INTERLOCKED_HL_RESULT, InterlockedHL_WaitForNotValue, LONG volatile*, address, LONG, value, DWORD, milliseconds)(INTERLOCKED_HL_OK, INTERLOCKED_HL_ERROR);
 MOCKABLE_FUNCTION_WITH_RETURNS(, INTERLOCKED_HL_RESULT, InterlockedHL_CompareExchange64If, LONG64 volatile*, target, LONG64, exchange, INTERLOCKED_COMPARE_EXCHANGE_64_IF, compare, LONG64 *, original_target)(INTERLOCKED_HL_OK, INTERLOCKED_HL_ERROR);
 
 #ifdef __cplusplus

--- a/tests/reals/real_interlocked_hl.h
+++ b/tests/reals/real_interlocked_hl.h
@@ -13,6 +13,7 @@
     MU_FOR_EACH_1(R2,                      \
         InterlockedHL_Add64WithCeiling, \
         InterlockedHL_WaitForValue, \
+        InterlockedHL_WaitForNotValue, \
         InterlockedHL_SetAndWake, \
         InterlockedHL_CompareExchange64If \
     )
@@ -25,9 +26,10 @@ extern "C" {
 
     INTERLOCKED_HL_RESULT real_InterlockedHL_Add64WithCeiling(LONGLONG volatile * Addend, LONGLONG Ceiling, LONGLONG Value, LONGLONG* originalAddend);
     INTERLOCKED_HL_RESULT real_InterlockedHL_WaitForValue(LONG volatile* address, LONG value, DWORD milliseconds);
+    INTERLOCKED_HL_RESULT real_InterlockedHL_WaitForNotValue(LONG volatile* address, LONG value, DWORD milliseconds);
     INTERLOCKED_HL_RESULT real_InterlockedHL_SetAndWake(LONG volatile* address, LONG value);
     INTERLOCKED_HL_RESULT real_InterlockedHL_CompareExchange64If(LONG64 volatile* target, LONG64 exchange, INTERLOCKED_COMPARE_EXCHANGE_64_IF compare, LONG64* original_target);
-    
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/reals/real_interlocked_hl_renames.h
+++ b/tests/reals/real_interlocked_hl_renames.h
@@ -2,6 +2,7 @@
 
 #define InterlockedHL_Add64WithCeiling real_InterlockedHL_Add64WithCeiling
 #define InterlockedHL_WaitForValue real_InterlockedHL_WaitForValue
+#define InterlockedHL_WaitForNotValue real_InterlockedHL_WaitForNotValue
 #define InterlockedHL_SetAndWake real_InterlockedHL_SetAndWake
 #define InterlockedHL_CompareExchange64If real_InterlockedHL_CompareExchange64If
 


### PR DESCRIPTION
Adds InterlockedHL_WaitForNotValue, which is InterlockedHL_WaitForValue except it waits for the value to equal anything else.