### PR TITLE
Fix real RC_STRING to not need STRICT_EXPECTED_CALL(malloc)

### DIFF
--- a/tests/reals/real_rc_string.c
+++ b/tests/reals/real_rc_string.c
@@ -3,5 +3,6 @@
 
 
 #include "real_rc_string_renames.h"
+#include "real_gballoc_hl_renames.h"
 
 #include "../../src/rc_string.c"


### PR DESCRIPTION
Fix real RC_STRING to not need STRICT_EXPECTED_CALL(malloc)