### PR TITLE
fix memory corruption

### DIFF
--- a/devdoc/channel_requirements.md
+++ b/devdoc/channel_requirements.md
@@ -305,8 +305,8 @@ channel_open` opens the given `channel`.
 
 **SRS_CHANNEL_43_148: [** If `channel_op_context` is `NULL`, `execute_callbacks` shall terminate the process. **]**
 
-**SRS_CHANNEL_43_157: [** `execute_callbacks` shall call `sm_exec_end` for each callback that is called. **]**
-
 **SRS_CHANNEL_43_145: [** `execute_callbacks` shall call the stored callback(s) with the `result` of the `operation`.  **]**
+
+**SRS_CHANNEL_43_157: [** `execute_callbacks` shall call `sm_exec_end` for each callback that is called. **]**
 
 **SRS_CHANNEL_43_147: [** `execute_callbacks` shall perform cleanup of the `operation`. **]**

--- a/src/channel.c
+++ b/src/channel.c
@@ -256,17 +256,6 @@ static void execute_callbacks(void* context)
 
         if (channel_op->on_data_available_cb != NULL)
         {
-            /*Codes_SRS_CHANNEL_43_157: [ execute_callbacks shall call sm_exec_end for each callback that is called. ]*/
-            sm_exec_end(channel_op->channel->sm);
-        }
-        if (channel_op->on_data_consumed_cb != NULL)
-        {
-            /*Codes_SRS_CHANNEL_43_157: [ execute_callbacks shall call sm_exec_end for each callback that is called. ]*/
-            sm_exec_end(channel_op->channel->sm);
-        }
-
-        if (channel_op->on_data_available_cb != NULL)
-        {
             /*Codes_SRS_CHANNEL_43_145: [ execute_callbacks shall call the stored callback(s) with the result of the operation. ]*/
             channel_op->on_data_available_cb(channel_op->on_data_available_context, result, channel_op->pull_correlation_id, channel_op->push_correlation_id, channel_op->data);
         }
@@ -274,6 +263,17 @@ static void execute_callbacks(void* context)
         {
             /*Codes_SRS_CHANNEL_43_145: [ execute_callbacks shall call the stored callback(s) with the result of the operation. ]*/
             channel_op->on_data_consumed_cb(channel_op->on_data_consumed_context, result, channel_op->pull_correlation_id, channel_op->push_correlation_id);
+        }
+
+        if (channel_op->on_data_available_cb != NULL)
+        {
+            /*Codes_SRS_CHANNEL_43_157: [ execute_callbacks shall call sm_exec_end for each callback that is called. ]*/
+            sm_exec_end(channel_op->channel->sm);
+        }
+        if (channel_op->on_data_consumed_cb != NULL)
+        {
+            /*Codes_SRS_CHANNEL_43_157: [ execute_callbacks shall call sm_exec_end for each callback that is called. ]*/
+            sm_exec_end(channel_op->channel->sm);
         }
 
         /*Codes_SRS_CHANNEL_43_147: [ execute_callbacks shall perform cleanup of the operation. ]*/


### PR DESCRIPTION
If channel calls sm_exec_end before calling the callbacks, it's possible that the channel will close before the callbacks get called.  Depending on the callbacks, this can lead to memory corruption.  In my case, geo_core was calling channel_close, and channel_close was returning (after sm_exec_end was called).  Then geo_core_destroy was called, and finally the channel callback(operation_rc_ptr_dispose) was called . This referred to a dead geo_core pointer, and it crashed. 