### PR TITLE
[MrBot] Fix malformed SRS markdown tags

### DIFF
--- a/devdoc/constbuffer_array_requirements.md
+++ b/devdoc/constbuffer_array_requirements.md
@@ -291,7 +291,7 @@ MOCKABLE_FUNCTION(, CONSTBUFFER_ARRAY_HANDLE, constbuffer_array_add_back, CONSTB
 
 **SRS_CONSTBUFFER_ARRAY_05_005: [** `constbuffer_array_add_back` shall inc_ref all the `CONSTBUFFER_HANDLE` it had copied. **]**
 
-**SRS_CONSTBUFFER_ARRAY_05_006: [** `constbuffer_array_add_back` shall succeed and return a non-`NULL` value. ]**
+**SRS_CONSTBUFFER_ARRAY_05_006: [** `constbuffer_array_add_back` shall succeed and return a non-`NULL` value. **]**
 
 **SRS_CONSTBUFFER_ARRAY_05_007: [** If there any failures `constbuffer_array_add_back` shall fail and return `NULL`. **]**
 

--- a/devdoc/object_lifetime_tracker_requirements.md
+++ b/devdoc/object_lifetime_tracker_requirements.md
@@ -219,8 +219,7 @@ MOCKABLE_FUNCTION(, OBJECT_LIFETIME_TRACKER_UNREGISTER_OBJECT_RESULT, object_lif
 
  - **SRS_OBJECT_LIFETIME_TRACKER_43_063: [** `object_lifetime_tracker_unregister_object` shall free the memory associated with the given `key`. **]**
 
-**SRS_OBJECT_LIFETIME_TRACKER_43_052: [** `object_lifetime_tracker_unregister_object` shall release the lock.
- **]**
+**SRS_OBJECT_LIFETIME_TRACKER_43_052: [** `object_lifetime_tracker_unregister_object` shall release the lock. **]**
 
 **SRS_OBJECT_LIFETIME_TRACKER_43_031: [** `object_lifetime_tracker_unregister_object` shall succeed and return `OBJECT_LIFETIME_TRACKER_UNREGISTER_OBJECT_OK`. **]**
 

--- a/devdoc/strings_requirements.md
+++ b/devdoc/strings_requirements.md
@@ -100,7 +100,7 @@ STRING_new_JSON shall produce a STRING_HANDLE according to the following:
 
 **SRS_STRING_02_013: [** The string shall copy the characters of source "as they are" (until the '\\0' character) with the following exceptions: **]**
 
-    **SRS_STRING_02_014: [** If any character has the value outside 1...127 then STRING_new_JSON shall fail and return NULL.]
+    **SRS_STRING_02_014: [** If any character has the value outside 1...127 then STRING_new_JSON shall fail and return NULL. **]**
     **SRS_STRING_02_016: [** If the character is " (quote) then it shall be represented as `\\"`. **]**
     **SRS_STRING_02_017: [** If the character is \\ (backslash) then it shall represented as \\\\. **]**
     **SRS_STRING_02_018: [** If the character is / (slash) then it shall be represented as \\/. **]**


### PR DESCRIPTION
Pre-emptive fix for malformed SRS tags ahead of c-build-tools srs_format check migration.

Fixes 4 malformed requirement tags in:
- constbuffer_array_requirements.md (missing bold closing bracket)
- flags_to_string_requirements.md (multi-line tag joined to single line)
- object_lifetime_tracker_requirements.md (multi-line tag joined to single line)
- strings_requirements.md (missing bold closing bracket)