### PR TITLE
ZZZ

### DIFF
--- a/build/devops_gated.yml
+++ b/build/devops_gated.yml
@@ -22,7 +22,7 @@ resources:
     type: github
     name: azure/c-build-tools
     endpoint: github.com_azure
-    ref: 7a1201d8c76bacc9994d6030cadcec98d107554c
+    ref: c3bbecea4479c5c76cd92dd480bfd223e19b3905
 jobs:
 - template: /pipeline_templates/build_all_flavors.yml@c_build_tools
   parameters:

--- a/build/devops_gated.yml
+++ b/build/devops_gated.yml
@@ -22,7 +22,7 @@ resources:
     type: github
     name: azure/c-build-tools
     endpoint: github.com_azure
-    ref: 3a6192f17dadb8642841bbc02b3dd1ab86dbca94
+    ref: 26190c664c53189ce01a3565f55f5d68980a53a3
 jobs:
 - template: /pipeline_templates/build_all_flavors.yml@c_build_tools
   parameters:

--- a/build/devops_gated.yml
+++ b/build/devops_gated.yml
@@ -22,7 +22,7 @@ resources:
     type: github
     name: azure/c-build-tools
     endpoint: github.com_azure
-    ref: c3bbecea4479c5c76cd92dd480bfd223e19b3905
+    ref: 6fa0ef33cadc6a97ca13552771871733762a9d44
 jobs:
 - template: /pipeline_templates/build_all_flavors.yml@c_build_tools
   parameters:

--- a/build/devops_gated.yml
+++ b/build/devops_gated.yml
@@ -22,10 +22,13 @@ resources:
     type: github
     name: azure/c-build-tools
     endpoint: github.com_azure
-    ref: 6fa0ef33cadc6a97ca13552771871733762a9d44
+    ref: 3a6192f17dadb8642841bbc02b3dd1ab86dbca94
 jobs:
 - template: /pipeline_templates/build_all_flavors.yml@c_build_tools
   parameters:
+    # Preserve existing x64 coverage of int / perf / e2e categories. The new
+    # c-build-tools strict UNIT_TESTS semantic would otherwise filter them out.
+    MAX_STAGE_x64: ALL
     GBALLOC_LL_TYPE_VALUES: ["PASSTHROUGH", "JEMALLOC"]
 
 - template: /pipeline_templates/run_master_check.yml@c_build_tools

--- a/build/devops_gated.yml
+++ b/build/devops_gated.yml
@@ -22,7 +22,7 @@ resources:
     type: github
     name: azure/c-build-tools
     endpoint: github.com_azure
-    ref: a23f683a6282efb5ea0482e7d31502f945242919
+    ref: 7a1201d8c76bacc9994d6030cadcec98d107554c
 jobs:
 - template: /pipeline_templates/build_all_flavors.yml@c_build_tools
   parameters:

--- a/build/devops_gated.yml
+++ b/build/devops_gated.yml
@@ -22,7 +22,7 @@ resources:
     type: github
     name: azure/c-build-tools
     endpoint: github.com_azure
-    ref: 3849e4ec73f27ff1cdb6b41fa4946e1091124e63
+    ref: 14149d5f394c747e3caf29fc0a745075cc459213
 jobs:
 - template: /pipeline_templates/build_all_flavors.yml@c_build_tools
   parameters:

--- a/build/devops_gated.yml
+++ b/build/devops_gated.yml
@@ -22,13 +22,10 @@ resources:
     type: github
     name: azure/c-build-tools
     endpoint: github.com_azure
-    ref: 26190c664c53189ce01a3565f55f5d68980a53a3
+    ref: e0bc7a1ec8c93a824e3542834d415615d92eeb76
 jobs:
 - template: /pipeline_templates/build_all_flavors.yml@c_build_tools
   parameters:
-    # Preserve existing x64 coverage of int / perf / e2e categories. The new
-    # c-build-tools strict UNIT_TESTS semantic would otherwise filter them out.
-    MAX_STAGE_x64: ALL
     GBALLOC_LL_TYPE_VALUES: ["PASSTHROUGH", "JEMALLOC"]
 
 - template: /pipeline_templates/run_master_check.yml@c_build_tools

--- a/build/devops_gated.yml
+++ b/build/devops_gated.yml
@@ -22,7 +22,7 @@ resources:
     type: github
     name: azure/c-build-tools
     endpoint: github.com_azure
-    ref: e25364682cf2239eda040a4b22aa333e9c8096b2
+    ref: 3849e4ec73f27ff1cdb6b41fa4946e1091124e63
 jobs:
 - template: /pipeline_templates/build_all_flavors.yml@c_build_tools
   parameters:

--- a/build/devops_gated.yml
+++ b/build/devops_gated.yml
@@ -22,7 +22,7 @@ resources:
     type: github
     name: azure/c-build-tools
     endpoint: github.com_azure
-    ref: e0bc7a1ec8c93a824e3542834d415615d92eeb76
+    ref: fb7a1faaac2eea2b8800e34d47ff15b22f0bd0c2
 jobs:
 - template: /pipeline_templates/build_all_flavors.yml@c_build_tools
   parameters:

--- a/build/devops_gated.yml
+++ b/build/devops_gated.yml
@@ -22,7 +22,7 @@ resources:
     type: github
     name: azure/c-build-tools
     endpoint: github.com_azure
-    ref: 14149d5f394c747e3caf29fc0a745075cc459213
+    ref: a23f683a6282efb5ea0482e7d31502f945242919
 jobs:
 - template: /pipeline_templates/build_all_flavors.yml@c_build_tools
   parameters:

--- a/build/devops_gated.yml
+++ b/build/devops_gated.yml
@@ -22,7 +22,7 @@ resources:
     type: github
     name: azure/c-build-tools
     endpoint: github.com_azure
-    ref: fb7a1faaac2eea2b8800e34d47ff15b22f0bd0c2
+    ref: 519a581202e6768d1ff0d23a8663847102658574
 jobs:
 - template: /pipeline_templates/build_all_flavors.yml@c_build_tools
   parameters:


### PR DESCRIPTION
Pin deps/c-build-tools and the GitHub-resource ref in build/devops_gated.yml to azure/c-build-tools@3849e4ec73f27ff1cdb6b41fa4946e1091124e63 to validate the new MAX_STAGE infrastructure (default UNIT_TESTS, no run_arm64_tests knob, ARM64 leg becomes blocking and runs unit tests).